### PR TITLE
Ignore footnotes in hast-util-to-string

### DIFF
--- a/packages/hast-util-to-string/index.js
+++ b/packages/hast-util-to-string/index.js
@@ -40,6 +40,10 @@ function one(node) {
   if (node.type === 'text') {
     return node.value
   }
+  
+  if (node.properties && node.properties.className && node.properties.className.includes('footnote-ref')) {
+    return '';
+  }
 
   return node.children ? all(node) : ''
 }


### PR DESCRIPTION
Ignore [footnotes](https://github.com/remarkjs/remark/blob/master/packages/remark-parse/readme.md#optionsfootnotes).

## Hast
```
AWS does offer a few products<sup id="fnref-nvcaorgblo.5gig5b"><a href="#fn-nvcaorgblo.5gig5b" class="footnote-ref">nvcaorgblo.5gig5b</a></sup> that fit into these other models, too.
```

## Turns into

### Before
```
AWS does offer a few productsnvcaorgblo.5gig5b that fit into these other models, too.
```

### After
```
AWS does offer a few products that fit into these other models, too.
```