### PR TITLE
rehype-minify-whitespace: inline element are trimmed

### DIFF
--- a/packages/rehype-minify-whitespace/index.js
+++ b/packages/rehype-minify-whitespace/index.js
@@ -119,6 +119,17 @@ function minify(tree, options) {
     return !node || inside || !collapsable(node)
   }
 
+  function findLastTextNode(element) {
+    var children = element.children
+    var child
+    while (children && children.length > 0) {
+      child = children[children.length - 1]
+      children = child.children
+    }
+
+    return child && text(child) ? child : null
+  }
+
   function trimLeft(value, previous) {
     value = whitespace(value)
     var end = value.length
@@ -129,10 +140,13 @@ function minify(tree, options) {
         start++
       } else {
         // if previous element is inline, check if last child has a trailing space
-        if (element(previous, list) && previous.children && previous.children.length > 0) {
-          var v = whitespace(previous.children[previous.children.length - 1].value)
-          if (v && empty(v.charAt(v.length - 1))) {
-            start++
+        if (element(previous, list)) {
+          var textNode = findLastTextNode(previous)
+          if (textNode) {
+            var v = whitespace(textNode.value)
+            if (v && empty(v.charAt(v.length - 1))) {
+              start++
+            }
           }
         } else {
           // if previous is a text, check if it has a trailing space
@@ -149,6 +163,17 @@ function minify(tree, options) {
     return value.slice(start, end)
   }
   
+  function findFirstTextNode(element) {
+    var children = element.children
+    var child
+    while (children && children.length > 0) {
+      child = children[0]
+      children = child.children
+    }
+
+    return child && text(child) ? child : null
+  }
+
   function trimRight(value, next) {
     value = whitespace(value)
     var end = value.length
@@ -159,10 +184,13 @@ function minify(tree, options) {
         end--
       } else {
         // if previous element is inline, check if first child has a leading space
-        if (element(next, list) && next.children && next.children.length > 0) {
-          var v = whitespace(next.children[0].value)
-          if (v && empty(v.charAt(0))) {
-            end--
+        if (element(next, list)) {
+          var textNode = findFirstTextNode(next);
+          if (textNode) {
+            var v = whitespace(textNode.value)
+            if (v && empty(v.charAt(0))) {
+              end--
+            }
           }
         } else {
           // if next is a text, check if it has a leading space

--- a/packages/rehype-minify-whitespace/index.js
+++ b/packages/rehype-minify-whitespace/index.js
@@ -56,10 +56,8 @@ function minify(tree, options) {
       previous = parent.children[index - 1]
       next = parent.children[index + 1]
 
-      console.log(`before text "${node.value}"`)
       value = trimLeft(node.value, previous)
       value = trimRight(value, next)
-      console.log(`after text "${value}"`)
 
       // Remove the node if it’s collapsed entirely.
       if (!value) {
@@ -87,10 +85,8 @@ function minify(tree, options) {
             next = node.children[i + 1]
           }
 
-          console.log(`before child "${child.value}"`)
           child.value = trimLeft(child.value, previous)
           child.value = trimRight(child.value, next)
-          console.log(`after child "${child.value}"`)
 
           // Remove the node if it’s collapsed entirely.
           if (!child.value) {

--- a/packages/rehype-minify-whitespace/index.js
+++ b/packages/rehype-minify-whitespace/index.js
@@ -48,8 +48,6 @@ function minify(tree, options) {
     var previous
     var next
     var value
-    var start
-    var end
 
     // text node which is not inside an inline element
     if (text(node) && !element(parent, list)) {

--- a/packages/rehype-minify-whitespace/index.js
+++ b/packages/rehype-minify-whitespace/index.js
@@ -73,17 +73,29 @@ function minify(tree, options) {
     // inline element, check children
     if (element(node, list)) {
       node.children.forEach((child, i) => {
-        previous = parent.children[index - 1]
-        next = parent.children[index + 1]
+        if (text(child)) {
+          if (i === 0) {
+            // previous is parent sibling
+            previous = parent.children[index - 1]
+          } else {
+            previous = node.children[i - 1]
+          }
 
-        console.log(`before child "${child.value}"`)
-        child.value = trimLeft(child.value, previous)
-        child.value = trimRight(child.value, next)
-        console.log(`after child "${child.value}"`)
+          if (i === node.children.length - 1) {
+            next = parent.children[index + 1]
+          } else {
+            next = node.children[i + 1]
+          }
 
-        // Remove the node if it’s collapsed entirely.
-        if (!child.value) {
-          node.children.splice(i, 1)
+          console.log(`before child "${child.value}"`)
+          child.value = trimLeft(child.value, previous)
+          child.value = trimRight(child.value, next)
+          console.log(`after child "${child.value}"`)
+
+          // Remove the node if it’s collapsed entirely.
+          if (!child.value) {
+            node.children.splice(i, 1)
+          }
         }
       })
     }

--- a/packages/rehype-minify-whitespace/index.js
+++ b/packages/rehype-minify-whitespace/index.js
@@ -24,40 +24,6 @@ var list = require('./list.json')
 
 var text = convert('text')
 
-var inlineElements = [
-  'b',
-  'big',
-  'i',
-  'small',
-  'tt',
-  'abbr',
-  'acronym',
-  'cite',
-  'code',
-  'dfn',
-  'em',
-  'kbd',
-  'strong',
-  'samp',
-  'var',
-  'a',
-  'bdo',
-  'br',
-  'img',
-  'map',
-  'object',
-  'q',
-  'script',
-  'span',
-  'sub',
-  'sup',
-  'button',
-  'input',
-  'label',
-  'select',
-  'textarea'
-]
-
 module.exports = collapse
 
 function collapse(options) {
@@ -93,7 +59,7 @@ function minify(tree, options) {
       end = value.length
       start = 0
 
-      if (!isInlineElement(parent)) {
+      if (!collapsable(parent)) {
         if (empty(value.charAt(0)) && viable(previous)) {
           start++
         }
@@ -157,8 +123,4 @@ function collapseToNewLines(value) {
 
 function empty(character) {
   return character === ' ' || character === '\n'
-}
-
-function isInlineElement(element) {
-  return element && element.tagName && inlineElements.indexOf(element.tagName) !== -1
 }

--- a/packages/rehype-minify-whitespace/index.js
+++ b/packages/rehype-minify-whitespace/index.js
@@ -24,6 +24,40 @@ var list = require('./list.json')
 
 var text = convert('text')
 
+var inlineElements = [
+  'b',
+  'big',
+  'i',
+  'small',
+  'tt',
+  'abbr',
+  'acronym',
+  'cite',
+  'code',
+  'dfn',
+  'em',
+  'kbd',
+  'strong',
+  'samp',
+  'var',
+  'a',
+  'bdo',
+  'br',
+  'img',
+  'map',
+  'object',
+  'q',
+  'script',
+  'span',
+  'sub',
+  'sup',
+  'button',
+  'input',
+  'label',
+  'select',
+  'textarea'
+]
+
 module.exports = collapse
 
 function collapse(options) {
@@ -59,12 +93,14 @@ function minify(tree, options) {
       end = value.length
       start = 0
 
-      if (empty(value.charAt(0)) && viable(previous)) {
-        start++
-      }
+      if (inlineElements.indexOf(parent.tagName) === -1) {
+        if (empty(value.charAt(0)) && viable(previous)) {
+          start++
+        }
 
-      if (empty(value.charAt(end - 1)) && viable(next)) {
-        end--
+        if (empty(value.charAt(end - 1)) && viable(next)) {
+          end--
+        }
       }
 
       value = value.slice(start, end)

--- a/packages/rehype-minify-whitespace/index.js
+++ b/packages/rehype-minify-whitespace/index.js
@@ -93,7 +93,7 @@ function minify(tree, options) {
       end = value.length
       start = 0
 
-      if (inlineElements.indexOf(parent.tagName) === -1) {
+      if (!isInlineElement(parent)) {
         if (empty(value.charAt(0)) && viable(previous)) {
           start++
         }
@@ -157,4 +157,8 @@ function collapseToNewLines(value) {
 
 function empty(character) {
   return character === ' ' || character === '\n'
+}
+
+function isInlineElement(element) {
+  return element && element.tagName && inlineElements.indexOf(element.tagName) !== -1
 }

--- a/packages/rehype-minify-whitespace/test.js
+++ b/packages/rehype-minify-whitespace/test.js
@@ -259,27 +259,37 @@ test('rehype-minify-whitespace', function(t) {
     ])
   )
 
-  // "optimise" span spacing
-  // t.deepEqual(
-  //   rehype()
-  //     .use(min)
-  //     .runSync(
-  //       h('main', [
-  //         h('span', [
-  //           'foo ',
-  //           h('a', {href: 'example.com'}, ' bar '),
-  //           ' baz',
-  //         ])
-  //       ])
-  //     ),
-  //   h('main', [
-  //     h('span', [
-  //       'foo ',
-  //       h('a', {href: 'example.com'}, 'bar'),
-  //       ' baz',
-  //     ])
-  //   ])
-  // )
+  // complex inline nesting
+  t.deepEqual(
+    rehype()
+      .use(min)
+      .runSync(
+        h('main', [
+          h('i', [
+            h('span', [
+              'foo ',
+            ]),
+            h('a', {href: 'example.com'}, [
+              h('span', [
+                'bar ',
+              ]),
+            ]),
+          ]),
+        ]),
+      ),
+    h('main', [
+      h('i', [
+        h('span', [
+          'foo ',
+        ]),
+        h('a', {href: 'example.com'}, [
+          h('span', [
+            'bar',
+          ]),
+        ]),
+      ]),
+    ])
+  )
 
   t.end()
 })

--- a/packages/rehype-minify-whitespace/test.js
+++ b/packages/rehype-minify-whitespace/test.js
@@ -39,7 +39,7 @@ test('rehype-minify-whitespace', function(t) {
         ' ',
         h('meta', {itemProp: true})
       ]),
-      h('p', [h('a', {href: 'example.com'}, 'baz'), ' ', h('em', 'qux')])
+      h('p', [h('a', {href: 'example.com'}, ' baz'), ' ', h('em', ' qux')])
     ])
   )
 
@@ -96,7 +96,30 @@ test('rehype-minify-whitespace', function(t) {
         '\n',
         h('meta', {itemProp: true})
       ]),
-      h('p', [h('a', {href: 'example.com'}, 'baz'), ' ', h('em', 'qux')])
+      h('p', [h('a', {href: 'example.com'}, ' baz'), ' ', h('em', ' qux')])
+    ])
+  )
+
+  t.deepEqual(
+    rehype()
+      .use(min)
+      .runSync(
+        h('main', [
+          h('p', [
+            h('strong', 'foo '),
+            h('em', 'bar '),
+            h('a', {href: 'example.com'}, ' baz '),
+            h('em', ' qux ')
+          ])
+        ])
+      ),
+    h('main', [
+      h('p', [
+        h('strong', 'foo '),
+        h('em', 'bar '),
+        h('a', {href: 'example.com'}, ' baz '),
+        h('em', ' qux ')
+      ])
     ])
   )
 

--- a/packages/rehype-minify-whitespace/test.js
+++ b/packages/rehype-minify-whitespace/test.js
@@ -238,26 +238,26 @@ test('rehype-minify-whitespace', function(t) {
   )
 
   // keep span spacing
-  // t.deepEqual(
-  //   rehype()
-  //     .use(min)
-  //     .runSync(
-  //       h('main', [
-  //         h('span', [
-  //           'foo ',
-  //           h('a', {href: 'example.com'}, 'bar'),
-  //           ' baz',
-  //         ])
-  //       ])
-  //     ),
-  //   h('main', [
-  //     h('span', [
-  //       'foo ',
-  //       h('a', {href: 'example.com'}, 'bar'),
-  //       ' baz',
-  //     ])
-  //   ])
-  // )
+  t.deepEqual(
+    rehype()
+      .use(min)
+      .runSync(
+        h('main', [
+          h('span', [
+            'foo ',
+            h('a', {href: 'example.com'}, 'bar'),
+            ' baz',
+          ])
+        ])
+      ),
+    h('main', [
+      h('span', [
+        'foo ',
+        h('a', {href: 'example.com'}, 'bar'),
+        ' baz',
+      ])
+    ])
+  )
 
   // "optimise" span spacing
   // t.deepEqual(

--- a/packages/rehype-minify-whitespace/test.js
+++ b/packages/rehype-minify-whitespace/test.js
@@ -237,29 +237,6 @@ test('rehype-minify-whitespace', function(t) {
     ])
   )
 
-  // keep span spacing
-  t.deepEqual(
-    rehype()
-      .use(min)
-      .runSync(
-        h('main', [
-          h('span', [
-            'foo ',
-            h('a', {href: 'example.com'}, 'bar'),
-            ' baz',
-          ])
-        ])
-      ),
-    h('main', [
-      h('span', [
-        'foo ',
-        h('a', {href: 'example.com'}, 'bar'),
-        ' baz',
-      ])
-    ])
-  )
-
-  // complex inline nesting
   t.deepEqual(
     rehype()
       .use(min)
@@ -290,6 +267,69 @@ test('rehype-minify-whitespace', function(t) {
       ]),
     ])
   )
+
+
+  // smart span spacing: UNSUPPORTED
+  // t.deepEqual(
+  //   rehype()
+  //     .use(min)
+  //     .runSync(
+  //       h('main', [
+  //         h('span', [
+  //           'foo ',
+  //           h('a', {href: 'example.com'}, 'bar'),
+  //           ' baz',
+  //         ])
+  //       ])
+  //     ),
+  //   h('main', [
+  //     h('span', [
+  //       'foo ',
+  //       h('a', {href: 'example.com'}, 'bar'),
+  //       ' baz',
+  //     ])
+  //   ])
+  // )
+
+  // deeper next: UNSUPPORTED
+  // t.deepEqual(
+  //   rehype()
+  //   .use(min)
+  //   .runSync(
+  //     h('main', [
+  //       h('p'), [
+  //         h('i', [
+  //           h('span', [
+  //             'foo ',
+  //           ]),
+  //         ]),
+  //         h('i', [
+  //           h('a', {href: 'example.com'}, [
+  //             h('span', [
+  //               'bar ',
+  //             ]),
+  //           ]),
+  //         ]),
+  //       ],
+  //     ]),
+  //   ),
+  //   h('main', [
+  //     h('p'), [
+  //       h('i', [
+  //         h('span', [
+  //           'foo ',
+  //         ]),
+  //       ]),
+  //       h('i', [
+  //         h('a', {href: 'example.com'}, [
+  //           h('span', [
+  //             'bar',
+  //           ]),
+  //         ]),
+  //       ]),
+  //     ],
+  //   ]),
+  // )
 
   t.end()
 })

--- a/packages/rehype-minify-whitespace/test.js
+++ b/packages/rehype-minify-whitespace/test.js
@@ -39,7 +39,10 @@ test('rehype-minify-whitespace', function(t) {
         ' ',
         h('meta', {itemProp: true})
       ]),
-      h('p', [h('a', {href: 'example.com'}, ' baz'), ' ', h('em', ' qux')])
+      h('p', [
+        h('a', {href: 'example.com'}, 'baz'),
+        h('em', ' qux')
+      ])
     ])
   )
 
@@ -96,7 +99,10 @@ test('rehype-minify-whitespace', function(t) {
         '\n',
         h('meta', {itemProp: true})
       ]),
-      h('p', [h('a', {href: 'example.com'}, ' baz'), ' ', h('em', ' qux')])
+      h('p', [
+        h('a', {href: 'example.com'}, 'baz'),
+        h('em', ' qux')
+      ])
     ])
   )
 
@@ -106,7 +112,7 @@ test('rehype-minify-whitespace', function(t) {
       .runSync(
         h('main', [
           h('p', [
-            h('strong', 'foo '),
+            h('strong', ' foo '),
             h('em', 'bar '),
             h('a', {href: 'example.com'}, ' baz '),
             h('em', ' qux ')
@@ -116,12 +122,164 @@ test('rehype-minify-whitespace', function(t) {
     h('main', [
       h('p', [
         h('strong', 'foo '),
-        h('em', 'bar '),
-        h('a', {href: 'example.com'}, ' baz '),
-        h('em', ' qux ')
+        h('em', 'bar'),
+        h('a', {href: 'example.com'}, ' baz'),
+        h('em', ' qux')
       ])
     ])
   )
+
+  t.deepEqual(
+    rehype()
+      .use(min)
+      .runSync(
+        h('main', [
+          h('p', [
+            ' foo ',
+            h('strong', ' bar '),
+            h('a', {href: 'example.com'}, ' baz '),
+            ' qux. '
+          ])
+        ])
+      ),
+    h('main', [
+      h('p', [
+        'foo',
+        h('strong', ' bar'),
+        h('a', {href: 'example.com'}, ' baz'),
+        ' qux.'
+      ])
+    ])
+  )
+
+  t.deepEqual(
+    rehype()
+      .use(min)
+      .runSync(
+        h('main', [
+          h('p', [
+            h('span', ' foo: '),
+            h('input', {type: 'button', value: 'baz'}),
+          ])
+        ])
+      ),
+    h('main', [
+      h('p', [
+        h('span', 'foo: '),
+        h('input', {type: 'button', value: 'baz'}),
+      ])
+    ])
+  )
+
+  t.deepEqual(
+    rehype()
+      .use(min, {newlines: true})
+      .runSync(
+        h('main', [
+          '  ',
+        ])
+      ),
+    h('main')
+  )
+
+  t.deepEqual(
+    rehype()
+      .use(min, {newlines: true})
+      .runSync(
+        h('main', [
+          h('p', [
+            '\n ',
+          ]),
+        ])
+      ),
+    h('main', [
+      h('p')
+    ])
+  )
+
+  t.deepEqual(
+    rehype()
+      .use(min)
+      .runSync(
+        h('main', [
+          '  ',
+          h('p'),
+          '  ',
+          h('p'),
+          '  '
+        ])
+      ),
+    h('main', [
+      h('p'),
+      h('p')
+    ])
+  )
+
+  t.deepEqual(
+    rehype()
+      .use(min)
+      .runSync(
+        h('main', [
+          '  ',
+          h('div', [
+            '  ',
+            ' foo ',
+            ' \n',
+            ' bar ',
+          ]),
+        ])
+      ),
+    h('main', [
+      h('div', [
+        'foo',
+        ' bar',
+      ])
+    ])
+  )
+
+  // keep span spacing
+  // t.deepEqual(
+  //   rehype()
+  //     .use(min)
+  //     .runSync(
+  //       h('main', [
+  //         h('span', [
+  //           'foo ',
+  //           h('a', {href: 'example.com'}, 'bar'),
+  //           ' baz',
+  //         ])
+  //       ])
+  //     ),
+  //   h('main', [
+  //     h('span', [
+  //       'foo ',
+  //       h('a', {href: 'example.com'}, 'bar'),
+  //       ' baz',
+  //     ])
+  //   ])
+  // )
+
+  // "optimise" span spacing
+  // t.deepEqual(
+  //   rehype()
+  //     .use(min)
+  //     .runSync(
+  //       h('main', [
+  //         h('span', [
+  //           'foo ',
+  //           h('a', {href: 'example.com'}, ' bar '),
+  //           ' baz',
+  //         ])
+  //       ])
+  //     ),
+  //   h('main', [
+  //     h('span', [
+  //       'foo ',
+  //       h('a', {href: 'example.com'}, 'bar'),
+  //       ' baz',
+  //     ])
+  //   ])
+  // )
 
   t.end()
 })


### PR DESCRIPTION
Fixes #19 

Inline elements like `a`, `span`, `em`... loses there leading and trailing whitespaces while those might be are important.

This PR is certainly requires some love, happy to improve the code and follow the guidelines.

Note that this changes the current behavior (see existing modified tests).