### PR TITLE
rehype-minify-whitespace: fix missing return tree

### DIFF
--- a/packages/rehype-minify-whitespace/index.js
+++ b/packages/rehype-minify-whitespace/index.js
@@ -38,6 +38,7 @@ function minifyWhitespace(options) {
 
   function transform(tree) {
     minify(tree, {collapse: collapse, whitespace: 'normal'})
+    return tree
   }
 }
 

--- a/packages/rehype-minify-whitespace/test.js
+++ b/packages/rehype-minify-whitespace/test.js
@@ -7,6 +7,14 @@ var h = require('hastscript')
 
 var min = require('.')
 
+test('rehype-minify-whitespace - api', function (t) {
+  t.deepEqual(
+    min({})(h('main')),
+    h('main'),
+    'should return a tree')
+  t.end()
+});
+
 test('rehype-minify-whitespace', function (t) {
   t.deepEqual(
     rehype()


### PR DESCRIPTION
Potential fix following up changes introduced by https://github.com/rehypejs/rehype-minify/issues/19

The current code does not work in the `hast-util-to-mdast` context.
