### PR TITLE
hast-util-is-css-link: update `trim`

### DIFF
--- a/packages/hast-util-is-css-link/package.json
+++ b/packages/hast-util-is-css-link/package.json
@@ -27,7 +27,7 @@
     "index.js"
   ],
   "dependencies": {
-    "trim": "^0.0.1"
+    "trim": "^1.0.0"
   },
   "xo": false
 }

--- a/packages/rehype-minify-attribute-whitespace/package.json
+++ b/packages/rehype-minify-attribute-whitespace/package.json
@@ -34,7 +34,7 @@
     "hast-util-has-property": "^1.0.0",
     "hast-util-is-element": "^1.0.0",
     "hast-util-is-event-handler": "^1.0.0",
-    "trim": "^0.0.1",
+    "trim": "^1.0.0",
     "unist-util-visit": "^2.0.0",
     "x-is-array": "^0.1.0"
   },


### PR DESCRIPTION
# Summary

This PR updates `trim` from `^0.0.1` to `^1.0.0`.

This change fixes reports of https://www.npmjs.com/advisories/1700 by `npm audit` and `yarn audit`.﻿
