### PR TITLE
rehype-remove-script-type-javascript: add example of `type="module"`

### DIFF
--- a/packages/rehype-remove-script-type-javascript/index.js
+++ b/packages/rehype-remove-script-type-javascript/index.js
@@ -3,8 +3,8 @@
  *   Remove `type` and `language` on JavaScript scripts.
  * @example
  *   <script type="text/javascript"></script>
- *   <script type="module"></script>
  *   <script language="javascript1.5"></script>
+ *   <script type="module"></script>
  */
 
 /**

--- a/packages/rehype-remove-script-type-javascript/index.js
+++ b/packages/rehype-remove-script-type-javascript/index.js
@@ -3,6 +3,7 @@
  *   Remove `type` and `language` on JavaScript scripts.
  * @example
  *   <script type="text/javascript"></script>
+ *   <script type="module"></script>
  *   <script language="javascript1.5"></script>
  */
 

--- a/packages/rehype-remove-script-type-javascript/readme.md
+++ b/packages/rehype-remove-script-type-javascript/readme.md
@@ -58,16 +58,16 @@ rehype input.html --use remove-script-type-javascript --output output.html
 
 ```html
 <script type="text/javascript"></script>
-<script type="module"></script>
 <script language="javascript1.5"></script>
+<script type="module"></script>
 ```
 
 ##### Out
 
 ```html
 <script></script>
-<script type="module"></script>
 <script></script>
+<script type="module"></script>
 ```
 
 ## Contribute

--- a/packages/rehype-remove-script-type-javascript/readme.md
+++ b/packages/rehype-remove-script-type-javascript/readme.md
@@ -58,6 +58,7 @@ rehype input.html --use remove-script-type-javascript --output output.html
 
 ```html
 <script type="text/javascript"></script>
+<script type="module"></script>
 <script language="javascript1.5"></script>
 ```
 
@@ -65,6 +66,7 @@ rehype input.html --use remove-script-type-javascript --output output.html
 
 ```html
 <script></script>
+<script type="module"></script>
 <script></script>
 ```
 

--- a/packages/rehype-remove-script-type-javascript/test.js
+++ b/packages/rehype-remove-script-type-javascript/test.js
@@ -47,5 +47,12 @@ test('rehype-remove-script-type-javascript', (t) => {
     u('root', [h('script', {language: 'fooscript'})])
   )
 
+  t.deepEqual(
+    rehype()
+      .use(min)
+      .runSync(u('root', [h('script', {type: 'module'})])),
+    u('root', [h('script', {type: 'module'})])
+  )
+
   t.end()
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This adds a test (and an example in the README) to confirm that the `type` property of `<script type="module">...</script>` is preserved by `rehype-remove-script-type-javascript`. When reading through the README for this package, my immediate concern was that inline module scripts would be converted to regular scripts, so hopefully this change will assuage that concern for future visitors. Also, the test makes sure there won’t be a regression here.

<!--do not edit: pr-->
